### PR TITLE
Fix opening with specified browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,10 +368,10 @@ LiveServer.start = function (options) {
 		if (openPath !== null)
 			if (typeof openPath === "object") {
 				openPath.forEach(function (p) {
-					open(openURL + p, { app: browser });
+					open(openURL + p, { app: { name: browser } });
 				});
 			} else {
-				open(openURL + openPath, { app: browser });
+				open(openURL + openPath, { app: { name: browser } });
 			}
 	});
 


### PR DESCRIPTION
`open` (unlike `opn`) [expects](https://github.com/sindresorhus/open/blob/7579417bbd3b3fc155b10f9b9b2eb71381e13e9a/index.js#L88=) an object of app info.

Without this change the value of `options.browser` is effectively ignored, and the default browser is used.